### PR TITLE
Fix mesos checks

### DIFF
--- a/mesos_master/datadog_checks/mesos_master/mesos_master.py
+++ b/mesos_master/datadog_checks/mesos_master/mesos_master.py
@@ -178,7 +178,7 @@ class MesosMaster(AgentCheck):
         return r.json()
 
     def _get_master_state(self, url, timeout, verify, tags):
-        return self._get_json(url + '/state.json', timeout, verify, tags)
+        return self._get_json(url + '/state', timeout, verify, tags)
 
     def _get_master_stats(self, url, timeout, verify, tags):
         if self.version >= [0, 22, 0]:
@@ -188,7 +188,7 @@ class MesosMaster(AgentCheck):
         return self._get_json(url + endpoint, timeout, verify, tags)
 
     def _get_master_roles(self, url, timeout, verify, tags):
-        return self._get_json(url + '/roles.json', timeout, verify, tags)
+        return self._get_json(url + '/roles', timeout, verify, tags)
 
     def _check_leadership(self, url, timeout, verify, tags=None):
         state_metrics = self._get_master_state(url, timeout, verify, tags)

--- a/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
+++ b/mesos_slave/datadog_checks/mesos_slave/mesos_slave.py
@@ -136,7 +136,7 @@ class MesosSlave(AgentCheck):
         return r.json()
 
     def _get_state(self, url, timeout, verify, tags):
-        return self._get_json(url + '/state.json', timeout, verify, tags)
+        return self._get_json(url + '/state', timeout, verify, tags)
 
     def _get_stats(self, url, timeout, verify, tags):
         if self.version >= [0, 22, 0]:


### PR DESCRIPTION
Starting from Mesos 1.8.0 the previously deprecated HTTP endpoints with `.json` suffix have been dropped: https://issues.apache.org/jira/browse/MESOS-4509

This is an exploratory hack to get the Mesos check to work again. I've tested this successfully with a custom check on our test environment.

Note that for versions < 1.8.0, the `.json` endpoints are still there, but so is the `/state` and `/roles` endpoints (not sure if they've been there forever or if they were introduced in a specific Mesos version).

Either way -- since the check uses the `/state.json` endpoint to check which version of Mesos is running (and that won't work on 1.8.0) it's maybe better to extend the configuration with an optional setting that decides if `/state.json` or `/state` should be used? The default could probably be `/state`.

*Or* allow the check to fall back to `/state.json` if `/state` returns a `404`?

> *Update*: The `/state.json` endpoint was deprecated in Mesos 0.25.0 (https://issues.apache.org/jira/browse/MESOS-2984).